### PR TITLE
chore: Create DNA hashes without `fixt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,6 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "clap 4.5.30",
- "fixt",
  "holochain",
  "holochain_client",
  "holochain_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,5 @@ tracing-subscriber = { version = "0.3.19", features = [
 url2 = "0.0.6"
 
 [dev-dependencies]
-fixt = "0.4.1"
 reqwest = { version = "0.12", features = ["rustls-tls"] }
 holochain = { version = "0.4.1", features = ["sweettest"] }

--- a/tests/zome_call.rs
+++ b/tests/zome_call.rs
@@ -1,12 +1,11 @@
 pub mod setup;
 
 use base64::{prelude::BASE64_URL_SAFE, Engine};
-use fixt::fixt;
+use holochain::core::DnaHash;
 use holochain_http_gateway::{
     config::{AllowedFns, Configuration},
     tracing::initialize_tracing_subscriber,
 };
-use holochain_types::dna::fixt::DnaHashFixturator;
 use reqwest::StatusCode;
 
 use setup::TestApp;
@@ -17,7 +16,7 @@ async fn zome_call_with_valid_params() {
 
     let app = TestApp::spawn().await;
 
-    let dna_hash = fixt!(DnaHash).to_string();
+    let dna_hash = DnaHash::from_raw_32(vec![1; 32]).to_string();
     let payload = r#"{"limit": 100, "offset": 10}"#;
     let payload = BASE64_URL_SAFE.encode(payload);
 
@@ -40,7 +39,7 @@ async fn zome_call_with_valid_params_but_no_payload() {
 
     let app = TestApp::spawn().await;
 
-    let dna_hash = fixt!(DnaHash).to_string();
+    let dna_hash = DnaHash::from_raw_32(vec![1; 32]).to_string();
 
     let response = app
         .call_zome(
@@ -68,7 +67,7 @@ async fn zome_call_with_payload_exceeding_limit_fails() {
 
     let app = TestApp::spawn_with_config(config).await;
 
-    let dna_hash = fixt!(DnaHash).to_string();
+    let dna_hash = DnaHash::from_raw_32(vec![1; 32]).to_string();
     let large_payload = r#"{"limit":100,"offset":0,"filters":{"author":"user123","tags":["important","featured","latest"],"content_contains":"search term","date_range":{"from":"2023-01-01","to":"2023-12-31"}}"#;
     let large_payload = BASE64_URL_SAFE.encode(large_payload);
 
@@ -92,7 +91,7 @@ async fn zome_call_with_invalid_json_payload_fails() {
     let app = TestApp::spawn().await;
 
     // Invalid JSON payload
-    let dna_hash = fixt!(DnaHash).to_string();
+    let dna_hash = DnaHash::from_raw_32(vec![1; 32]).to_string();
     let invalid_payload = r#"{"limit":10, offset: 0,}"#;
     let invalid_payload = BASE64_URL_SAFE.encode(invalid_payload);
 
@@ -139,7 +138,7 @@ async fn zome_call_with_non_base64_encoded_payload_fails() {
 
     let app = TestApp::spawn().await;
 
-    let dna_hash = fixt!(DnaHash).to_string();
+    let dna_hash = DnaHash::from_raw_32(vec![1; 32]).to_string();
     // Sending a raw JSON string without base64 encoding
     let payload = r#"{"limit":10}"#;
 


### PR DESCRIPTION
I'd rather do without the dependency on `fixt`. Its value really comes in when creating more complex types that are more work to construct and given that we're not doing anything with the contents of the `DnaHash`, it's not useful to have randomized values.