### PR TITLE
refactor(error)!: simplify error responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d31fea2b6e18dfe892863c3a0a68f9e005b0195565f3d55b8612946ebca789cc"
+dependencies = [
+ "assert2-macros",
+ "diff",
+ "is-terminal",
+ "yansi",
+]
+
+[[package]]
+name = "assert2-macros"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ac052c642f6d94e4be0b33028b346b7ab809ea5432b584eb8859f12f7ad2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,6 +2739,7 @@ name = "holochain_http_gateway"
 version = "0.1.0-alpha.0"
 dependencies = [
  "anyhow",
+ "assert2",
  "axum",
  "base64 0.22.1",
  "clap 4.5.30",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ futures = "0.3"
 [dev-dependencies]
 holochain_http_gateway = { path = ".", features = ["test-utils"] }
 
+assert2 = "0.3.15"
 fixt = "0.4.1"
 holochain = { version = "0.4.1", features = ["sweettest"] }
 http-body-util = "0.1.2"

--- a/src/app_conn_pool.rs
+++ b/src/app_conn_pool.rs
@@ -197,13 +197,13 @@ impl AppConnPool {
         tracing::info!("Connecting to app websocket at {}:{}", host, app_port);
 
         // Build a connection request
-        let request =
-            ConnectRequest::from(format!("{host}:{app_port}").parse::<SocketAddr>().map_err(
-                |e| {
-                    HcHttpGatewayError::ConfigurationError(format!("Invalid socket address: {}", e))
-                },
-            )?)
-            .try_set_header("Origin", HTTP_GW_ORIGIN)?;
+        let request = ConnectRequest::from(
+            format!("{host}:{app_port}")
+                .parse::<SocketAddr>()
+                .expect("Host and app port must be valid"),
+        )
+        .try_set_header("Origin", HTTP_GW_ORIGIN)
+        .expect("Origin headers have gone out of fashion");
 
         // Create a websocket client configuration and lower the default timeout. We are connecting
         // locally to a running Holochain. If requests take longer than the configured timeout then

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,46 +3,18 @@
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use holochain_types::{dna::HoloHashError, prelude::SerializedBytesError};
 use serde::Serialize;
 
 /// Core HTTP Gateway error type
 #[derive(thiserror::Error, Debug)]
 pub enum HcHttpGatewayError {
-    /// System-level I/O errors
-    #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
-    /// Configuration parsing errors
-    #[error("Configuration error: {0}")]
-    ConfigurationError(String),
-    /// URI path errors
-    #[error("Path error: {0}")]
-    PathError(#[from] axum::extract::rejection::PathRejection),
-    /// Identifier length exceeded
-    #[error("Identifier length exceeded: {0} has more than {1} characters")]
-    IdentifierLengthExceeded(String, u8),
-    /// Base64 decode errors
-    #[error("Base64 decode error: {0}")]
-    Base64DecodeError(#[from] base64::DecodeError),
-    /// Holo hash errors
-    #[error("HoloHash error: {0}")]
-    DnaHashError(#[from] HoloHashError),
-    /// Errors deserializing zome call payload to JSON
-    #[error("Failed to deserialize JSON to serde_json::Value: {0}")]
-    InvalidJSON(#[from] serde_json::Error),
-    /// Payload size exceeded
-    #[error("Payload size ({size} bytes) exceeds maximum allowed size ({limit} bytes)")]
-    PayloadSizeLimitError {
-        /// Current size of payload
-        size: u32,
-        /// Allowed payload size limit
-        limit: u32,
-    },
-    /// ExternIO encoding error
-    #[error("Failed to serialize payload to ExternIO: {0}")]
-    PayloadSerializationError(#[from] SerializedBytesError),
+    /// Request malformed error. This includes all request validation errors such as
+    /// invalid request path, excess identifier length, invalid DNA hash and invalid
+    /// encodings.
+    #[error("Request is malformed: {0}")]
+    RequestMalformed(String),
     /// Calling an unauthorized function
-    #[error("Function {fn_name} in zome {zome_name} in app {app_id} is not allowed")]
+    #[error("Function {fn_name} in zome {zome_name} in app {app_id} is not authorized")]
     UnauthorizedFunction {
         /// App id
         app_id: String,
@@ -51,7 +23,7 @@ pub enum HcHttpGatewayError {
         /// Function name
         fn_name: String,
     },
-    /// Handles Holochain errors
+    /// Holochain errors
     #[error("Holochain error: {0}")]
     HolochainError(#[from] holochain_client::ConductorApiError),
     /// Error returned when a connection cannot be made to the upstream Holochain service
@@ -85,80 +57,28 @@ impl From<&str> for ErrorResponse {
 impl IntoResponse for HcHttpGatewayError {
     fn into_response(self) -> axum::response::Response {
         match self {
-            HcHttpGatewayError::PathError(e) => {
-                tracing::error!("Path error: {}", e);
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse::from("Invalid request path")),
-                )
-            }
-            HcHttpGatewayError::IdentifierLengthExceeded(identifier, max_length) => {
-                let message =
-                    format!("Identifier {identifier} longer than {max_length} characters");
-                tracing::error!(message);
-                (StatusCode::BAD_REQUEST, Json(ErrorResponse::from(message)))
-            }
-            HcHttpGatewayError::Base64DecodeError(e) => {
-                tracing::error!("Base64 decode error: {}", e);
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse::from(
-                        "Failed to decode base64 encoded string",
-                    )),
-                )
-            }
-            HcHttpGatewayError::DnaHashError(e) => {
-                tracing::error!("DnaHash error: {}", e);
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse::from("Invalid base64 DNA hash")),
-                )
-            }
-            HcHttpGatewayError::InvalidJSON(e) => {
-                tracing::error!("Invalid JSON: {}", e);
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse::from("Payload contains invalid JSON")),
-                )
-            }
-            HcHttpGatewayError::PayloadSizeLimitError { size, limit } => {
-                let message = format!(
-                    "Payload size ({size} bytes) exceeds maximum allowed size ({limit} bytes)"
-                );
-                tracing::error!(message);
-                (StatusCode::BAD_REQUEST, Json(ErrorResponse::from(message)))
-            }
-            HcHttpGatewayError::PayloadSerializationError(e) => {
-                tracing::error!("Failed to serialize payload to ExternIO: {e}");
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse::from(
-                        "Failed to serialize payload to ExternIO",
-                    )),
-                )
-            }
+            HcHttpGatewayError::RequestMalformed(e) => (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::from(format!("Request is malformed: {e}"))),
+            ),
             HcHttpGatewayError::UnauthorizedFunction {
                 app_id,
                 zome_name,
                 fn_name,
-            } => {
-                let message = format!(
+            } => (
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse::from(format!(
                     "Function {fn_name} in zome {zome_name} in app {app_id} is not allowed"
-                );
-                tracing::error!(message);
-                (StatusCode::FORBIDDEN, Json(ErrorResponse::from(message)))
-            }
+                ))),
+            ),
             HcHttpGatewayError::UpstreamUnavailable => (
                 StatusCode::BAD_GATEWAY,
                 Json(ErrorResponse::from("Could not connect to Holochain")),
             ),
-            e => {
-                tracing::error!("Internal Error: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::from("Something went wrong")),
-                )
-            }
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::from("Something went wrong")),
+            ),
         }
         .into_response()
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,9 +1,6 @@
 //! HTTP gateway service for Holochain
 
-use crate::{
-    config::Configuration, error::HcHttpGatewayResult, router::hc_http_gateway_router,
-    HcHttpGatewayError,
-};
+use crate::{config::Configuration, router::hc_http_gateway_router};
 use axum::Router;
 use std::net::{IpAddr, SocketAddr};
 use tokio::net::TcpListener;
@@ -27,7 +24,7 @@ impl HcHttpGatewayService {
         address: impl Into<IpAddr>,
         port: u16,
         configuration: Configuration,
-    ) -> HcHttpGatewayResult<Self> {
+    ) -> std::io::Result<Self> {
         tracing::info!("Configuration: {:?}", configuration);
 
         let router = hc_http_gateway_router(configuration);
@@ -38,20 +35,16 @@ impl HcHttpGatewayService {
     }
 
     /// Get the socket address the service is configured to use
-    pub fn address(&self) -> HcHttpGatewayResult<SocketAddr> {
-        self.listener
-            .local_addr()
-            .map_err(HcHttpGatewayError::IoError)
+    pub fn address(&self) -> std::io::Result<SocketAddr> {
+        self.listener.local_addr()
     }
 
     /// Start the HTTP server and run until terminated
-    pub async fn run(self) -> HcHttpGatewayResult<()> {
+    pub async fn run(self) -> std::io::Result<()> {
         let address = self.address()?;
 
         tracing::info!("Starting server on {}", address);
-        axum::serve(self.listener, self.router)
-            .await
-            .inspect_err(|e| tracing::error!("Failed to bind to {}: {}", address, e))?;
+        axum::serve(self.listener, self.router).await?;
 
         Ok(())
     }

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -3,9 +3,7 @@ use holochain::sweettest::SweetConductor;
 use holochain_client::{AdminWebsocket, CellInfo, ConductorApiError, ExternIO, ZomeCallTarget};
 use holochain_http_gateway::config::{AllowedFns, Configuration, ZomeFn};
 use holochain_http_gateway::tracing::initialize_tracing_subscriber;
-use holochain_http_gateway::{
-    AppConnPool, HcHttpGatewayError, HcHttpGatewayResult, HTTP_GW_ORIGIN,
-};
+use holochain_http_gateway::{AppConnPool, HcHttpGatewayError, HTTP_GW_ORIGIN};
 use holochain_types::app::DisabledAppReason;
 use std::net::Ipv4Addr;
 
@@ -40,7 +38,7 @@ async fn connect_app_websocket() {
     let apps = admin_ws.list_apps(None).await.unwrap();
     assert_eq!(apps.len(), 2);
 
-    let pool = AppConnPool::new(create_test_configuration(admin_port).unwrap());
+    let pool = AppConnPool::new(create_test_configuration(admin_port));
 
     let app_client_1 = pool
         .get_or_connect_app_client("fixture1".to_string(), admin_ws.clone())
@@ -92,7 +90,7 @@ async fn reuse_connection() {
         .await
         .unwrap();
 
-    let pool = AppConnPool::new(create_test_configuration(admin_port).unwrap());
+    let pool = AppConnPool::new(create_test_configuration(admin_port));
 
     let app_client_1 = pool
         .get_or_connect_app_client("fixture1".to_string(), admin_ws.clone())
@@ -160,7 +158,7 @@ async fn does_not_reconnect_on_non_websocket_error() {
         .await
         .unwrap();
 
-    let pool = AppConnPool::new(create_test_configuration(admin_port).unwrap());
+    let pool = AppConnPool::new(create_test_configuration(admin_port));
 
     // Connect while the app is running
     let app_client = pool
@@ -247,7 +245,7 @@ async fn reconnect_on_failed_websocket() {
         .await
         .unwrap();
 
-    let pool = AppConnPool::new(create_test_configuration(admin_port).unwrap());
+    let pool = AppConnPool::new(create_test_configuration(admin_port));
 
     // Connect while the app is running
     let app_client = pool
@@ -336,7 +334,7 @@ async fn reconnect_gives_up() {
         .await
         .unwrap();
 
-    let pool = AppConnPool::new(create_test_configuration(admin_port).unwrap());
+    let pool = AppConnPool::new(create_test_configuration(admin_port));
 
     // Connect while the app is running
     let app_client = pool
@@ -502,7 +500,7 @@ async fn close_old_connections_on_limit() {
     assert_eq!(ws_for_apps, vec!["app_1", "app_3"]);
 }
 
-fn create_test_configuration(admin_port: u16) -> HcHttpGatewayResult<Configuration> {
+fn create_test_configuration(admin_port: u16) -> Configuration {
     Configuration::try_new(
         &format!("ws://127.0.0.1:{}", admin_port),
         "",
@@ -536,4 +534,5 @@ fn create_test_configuration(admin_port: u16) -> HcHttpGatewayResult<Configurati
         "",
         "",
     )
+    .unwrap()
 }


### PR DESCRIPTION
Combine all errors related to request path validation and transcoding under one error variant and remove error tracing for them.