### PR TITLE
chore: update `serde_json` to use Holochain fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
  "petgraph",
  "regex",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "tracing",
  "tracing-core",
  "tracing-serde 0.1.3",
@@ -527,7 +527,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
@@ -2278,6 +2278,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hc_serde_json"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049eba3ff81c89d682e35e0b6de79cb6d359fe37198f686213915ad57b694b42"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "hc_sleuth"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,7 +2549,7 @@ dependencies = [
  "sd-notify",
  "serde",
  "serde_bytes",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "serde_yaml",
  "shrinkwraprs",
  "sodoken 0.0.11",
@@ -2611,7 +2623,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_bytes",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "thiserror 1.0.69",
  "tracing",
  "url",
@@ -2709,6 +2721,7 @@ dependencies = [
  "base64 0.22.1",
  "clap 4.5.32",
  "futures",
+ "hc_serde_json",
  "holochain",
  "holochain_client",
  "holochain_conductor_api",
@@ -2720,7 +2733,6 @@ dependencies = [
  "mockall 0.13.1",
  "reqwest",
  "serde",
- "serde_json 1.0.140 (git+https://github.com/ThetaSinner/json.git?branch=master)",
  "thiserror 2.0.12",
  "tokio",
  "tower",
@@ -2828,7 +2840,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_bytes",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -2859,7 +2871,7 @@ dependencies = [
  "serde",
  "serde-transcode",
  "serde_bytes",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "thiserror 1.0.69",
 ]
 
@@ -2908,7 +2920,7 @@ dependencies = [
  "rusqlite",
  "scheduled-thread-pool",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "shrinkwraprs",
  "sodoken 0.0.11",
  "sqlformat",
@@ -2948,7 +2960,7 @@ dependencies = [
  "one_err",
  "parking_lot 0.12.3",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "shrinkwraprs",
  "tempfile",
  "thiserror 1.0.69",
@@ -2987,7 +2999,7 @@ dependencies = [
  "derive_more",
  "inferno",
  "once_cell",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "thiserror 1.0.69",
  "tracing",
  "tracing-core",
@@ -3040,7 +3052,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "serde_with",
  "serde_yaml",
  "shrinkwraprs",
@@ -3793,7 +3805,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_bytes",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -3999,7 +4011,7 @@ dependencies = [
  "rustls 0.21.12",
  "serde",
  "serde_bytes",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "sysinfo",
  "thiserror 1.0.69",
  "tokio",
@@ -4047,7 +4059,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "rcgen",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "serde_yaml",
  "tokio",
  "toml",
@@ -4818,7 +4830,7 @@ dependencies = [
  "indexmap 1.9.3",
  "libc",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
 ]
 
 [[package]]
@@ -5836,7 +5848,7 @@ dependencies = [
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -6392,17 +6404,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.140"
-source = "git+https://github.com/ThetaSinner/json.git?branch=master#3e73f79d434d11355cae821821e46c7947d22bd6"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_path_to_error"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6446,7 +6447,7 @@ dependencies = [
  "indexmap 2.8.0",
  "serde",
  "serde_derive",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "serde_with_macros",
  "time",
 ]
@@ -7315,7 +7316,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -7396,7 +7397,7 @@ dependencies = [
  "bit_field",
  "futures",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "tokio",
  "tracing",
  "tx5-core",
@@ -7415,7 +7416,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "sha2",
  "tempfile",
  "tokio",
@@ -7731,7 +7732,7 @@ dependencies = [
  "pin-project",
  "scoped-tls",
  "serde",
- "serde_json 1.0.140 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ holochain_conductor_api = "0.4.1"
 holochain_types = "0.4.1"
 holochain_websocket = "0.4.1"
 serde = { version = "=1.0.203", features = ["derive"] }
-serde_json = { version = "1.0.140", git = "https://github.com/ThetaSinner/json.git", branch = "master" }
+serde_json = { package = "hc_serde_json", version = "1.0.141" }
 thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "macros", "net"] }
 tracing = "0.1.41"


### PR DESCRIPTION
As part of #42.

The fork contains binary array deserialization.