### PR TITLE
chore: update rustc to 1.84.0

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
+watch_file rust-toolchain.toml
+
 use flake

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.84.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
This is required for the release automation, see: https://github.com/holochain/hc-http-gw/actions/runs/16076051347/job/45371420305#step:7:28.