### PR TITLE
chore: add missing CI devShell in flake.nix

### DIFF
--- a/.github/workflows/cargo_update.yaml
+++ b/.github/workflows/cargo_update.yaml
@@ -18,8 +18,7 @@ jobs:
           install_url: https://releases.nixos.org/nix/nix-2.28.3/install
 
       - name: Flake update
-        run: |
-          nix develop .#ci --command cargo update
+        run: nix develop .#ci --command cargo update
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/flake.nix
+++ b/flake.nix
@@ -19,27 +19,34 @@
 
       formatter = pkgs.nixpkgs-fmt;
 
-      devShells.default =
+      devShells =
         let
           rustFromFile = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         in
-        pkgs.mkShell {
-          packages = (with inputs'.holonix.packages; [
-            holochain
-            hc
-          ]) ++ [
-            pkgs.perl
-            pkgs.go
-            pkgs.cmake
-            rustFromFile
-          ];
+        {
+          default = pkgs.mkShell {
+            packages = (with inputs'.holonix.packages; [
+              holochain
+              hc
+            ]) ++ [
+              pkgs.perl
+              pkgs.go
+              pkgs.cmake
+              rustFromFile
+            ];
 
-          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+            RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
 
-          shellHook = ''
-            export PS1='\[\033[1;34m\][holonix:\w]\$\[\033[0m\] '
-          '';
+            shellHook = ''
+              export PS1='\[\033[1;34m\][holonix:\w]\$\[\033[0m\] '
+            '';
+          };
+          ci = pkgs.mkShell {
+            packages = [
+              rustFromFile
+            ];
+          };
         };
     };
   };


### PR DESCRIPTION
The [`cargo_update` CI workflow](https://github.com/holochain/hc-http-gw/blob/da9a0524ef1eb5ae2bc42d0362b5b01949e74c17/.github/workflows/cargo_update.yaml#L21) uses a devShell `ci` to perform the `cargo update` command, and that devShell doesn't exist right now.

The `ci` devShell is only used to perform `cargo update`, so none of the build or test dependencies should be required.