### PR TITLE
docs: update local gateway workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![API Docs](https://docs.rs/holochain_http_gateway/badge.svg)](https://docs.rs/holochain_http_gateway)
 [![Discord](https://img.shields.io/badge/Discord-blue.svg?style=flat-square)](https://discord.gg/k55DS5dmPH)
 
-The Holochain HTTP Gateway for providing a way to bridge from the web2 world into Holochain. Read the [spec](./spec.md) for more details.
+The Holochain HTTP Gateway provides a way to bridge from the web2 world into
+Holochain. Read the [spec](./spec.md) for more details.
 
 ## Compatibility
 
@@ -13,13 +14,21 @@ The Holochain HTTP Gateway for providing a way to bridge from the web2 world int
 | 0.4.x             | 0.1.x                |
 | 0.5.x             | 0.2.x                |
 | 0.6.x             | 0.3.x                |
+| 0.7.x             | 0.4.x                |
 
 ## Running HTTP Gateway locally
 
 ### Prerequisites
 
-Enter the Nix `devShell` with `nix develop` or make sure that you have `rustup`
-and `holochain-cli` installed.
+Enter the Nix development shell. It provides the versions of Rust, Holochain,
+and the `hc` CLI that are compatible with this checkout:
+
+```bash
+nix develop
+```
+
+Run the commands below from the repository root. Open each new terminal with
+`nix develop` before continuing in it.
 
 ### Instructions
 
@@ -36,18 +45,26 @@ Holochain process, entering a passphrase when prompted:
 hc sandbox create --in-process-lair
 ```
 
-Run the sandboxed conductor and enter the same passphrase as entered when
-creating it:
+Run the sandboxed conductor. Enter a new passphrase when prompted and leave the
+conductor running in this terminal:
 
 ```bash
 hc sandbox run
 ```
 
-Make note of the `admin_port`
+Make note of the `admin_port`:
 
 ```console
 machine:hc-http-gw$ hc sandbox run
 hc-sandbox: Conductor launched #!0 {"admin_port":41191,"app_ports":[]}
+```
+
+In a second terminal, enter the Nix development shell and set `ADMIN_PORT` to
+the value printed by `hc sandbox run`:
+
+```bash
+nix develop
+export ADMIN_PORT=41191
 ```
 
 In a separate terminal, also in the Nix `devShell`, we need to install the hApps that you want to use.
@@ -58,25 +75,28 @@ first with the `package` script:
 ./fixture/package.sh
 ```
 
-Install the test fixture with:
+Install and enable the test fixture through the conductor's admin interface:
 
 ```bash
-hc sandbox call install-app fixture/package/happ1/fixture1.happ
+hc client call --port "$ADMIN_PORT" install-app \
+  fixture/package/happ1/fixture1.happ
 ```
 
-Now run the gateway, setting the address of the admin websocket to `localhost`,
-the port to the `admin_port` that was printed when running the sandboxed
-conductor, the allowed apps to the installed fixture and the allowed
-functions to the functions from the test fixture.
+Run the gateway in the same terminal. The configuration connects it to the
+conductor and permits HTTP calls to `coordinator1/get_all_1` in `fixture1`:
 
 ```bash
-HC_GW_ADMIN_WS_URL="ws://localhost:41191" HC_GW_ALLOWED_APP_IDS="fixture1" HC_GW_ALLOWED_FNS_fixture1="coordinator1/get_all_1" cargo run
+HC_GW_ADMIN_WS_URL="ws://localhost:$ADMIN_PORT" \
+  HC_GW_ALLOWED_APP_IDS="fixture1" \
+  HC_GW_ALLOWED_FNS_fixture1="coordinator1/get_all_1" \
+  cargo run
 ```
 
-In another new terminal, also in the Nix `devShell`, check that we get a response to the health-check:
+In a third terminal, enter the Nix development shell and check the health
+endpoint:
 
 ```bash
-curl -i localhost:8090/health
+nix develop -c curl -i localhost:8090/health
 ```
 
 ```console
@@ -89,24 +109,29 @@ date: Wed, 12 Mar 2025 15:25:13 GMT
 Ok⏎
 ```
 
-For the next steps, we'll need the DNA hash that the app was installed with.
+For the next steps, set `ADMIN_PORT` again and list the installed DNA hashes:
 
 ```bash
-hc sandbox call list-dnas
+export ADMIN_PORT=41191
+hc client call --port "$ADMIN_PORT" list-dnas
 ```
 
 ```console
-machine:hc-http-gw$ hc sandbox call list-dnas
-hc-sandbox: DNAs: [DnaHash(uhC0kwgZaQK05lgFwcYb_LrtAXTAckaS41nxNVO_zRMdpsuAeA0uN)]
+machine:hc-http-gw$ hc client call --port "$ADMIN_PORT" list-dnas
+["uhC0kwgZaQK05lgFwcYb_LrtAXTAckaS41nxNVO_zRMdpsuAeA0uN"]
 ```
 
-The value you need is `uhC0kwgZaQK05lgFwcYb_LrtAXTAckaS41nxNVO_zRMdpsuAeA0uN`.
-
-Calling the `get_all_1` function on the fixture using the DNA hash found above should 
-now return an empty JSON array:
+Copy the returned value into `DNA_HASH`:
 
 ```bash
-curl -i localhost:8090/uhC0kwgZaQK05lgFwcYb_LrtAXTAckaS41nxNVO_zRMdpsuAeA0uN/fixture1/coordinator1/get_all_1
+export DNA_HASH=uhC0kwgZaQK05lgFwcYb_LrtAXTAckaS41nxNVO_zRMdpsuAeA0uN
+```
+
+Calling `get_all_1` through the gateway should now return an empty JSON array:
+
+```bash
+curl -i \
+  "localhost:8090/$DNA_HASH/fixture1/coordinator1/get_all_1"
 ```
 
 ```console
@@ -116,25 +141,29 @@ content-type: text/plain; charset=utf-8
 content-length: 2
 date: Wed, 12 Mar 2025 15:26:00 GMT
 
-[]⏎
+[]
 ```
 
-Now let's add some data. First, authorise the zome call:
+Add some data directly through the Holochain client. First, authorize zome
+calls for the fixture. Enter a new passphrase when prompted; the client stores
+the encrypted signing credentials in `.hc_auth` in the current directory:
 
 ```bash
-hc sandbox zome-call-auth fixture1
+hc client zome-call-auth --port "$ADMIN_PORT" fixture1
 ```
 
-and create the data:
+Create an entry, entering the same client passphrase when prompted:
 
 ```bash
-hc sandbox zome-call fixture1 uhC0kwgZaQK05lgFwcYb_LrtAXTAckaS41nxNVO_zRMdpsuAeA0uN coordinator1 create_1 'null'
+hc client zome-call --port "$ADMIN_PORT" fixture1 "$DNA_HASH" \
+  coordinator1 create_1 'null'
 ```
 
-Now the created data can be retrieved with
+The created data can now be retrieved through the gateway:
 
 ```bash
-curl -i localhost:8090/uhC0kwgZaQK05lgFwcYb_LrtAXTAckaS41nxNVO_zRMdpsuAeA0uN/fixture1/coordinator1/get_all_1
+curl -i \
+  "localhost:8090/$DNA_HASH/fixture1/coordinator1/get_all_1"
 ```
 
 ```console
@@ -144,7 +173,7 @@ content-type: text/plain; charset=utf-8
 content-length: 50
 date: Wed, 12 Mar 2025 17:54:50 GMT
 
-[{"value":"create_1_2025-03-12T17:54:06.337428Z"}]⏎
+[{"value":"create_1_2025-03-12T17:54:06.337428Z"}]
 ```
 
 ## Testing HTTP Gateway


### PR DESCRIPTION
## What changed

The local setup guide now uses the current hc client commands for installing the fixture, listing DNA hashes, authorizing zome calls, and creating fixture data. It also explains how to carry the conductor admin port between terminals and records the Holochain 0.7.x compatibility range.

## Why

The previous guide used hc sandbox commands that are no longer available, so a new checkout could not follow the documented workflow.

## Notes

Verified end to end in the Nix development shell. Fixture packaging, gateway health checks, read and write calls, the full Rust test suite, and Markdown lint all pass.

Closes #93