### PR TITLE
chore: fix holochain_serialized_bytes version to an actual number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ http-body-util = "0.1"
 mockall = "0.14"
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
 tower = "0.5"
-holochain_serialized_bytes = "*"
+holochain_serialized_bytes = "0.0.57"
 
 [features]
 test-utils = []

--- a/fixture/Cargo.toml
+++ b/fixture/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 hdi = "0.7.3"
 hdk = "0.6.3"
-holochain_serialized_bytes = "*"
+holochain_serialized_bytes = "0.0.57"
 serde = "1.0"
 
 integrity = { path = "integrity" }


### PR DESCRIPTION
Publishing to crates.io requires that all dependencies have a version specified and doesn't allow wildcard versions.